### PR TITLE
add regex to clean_authors to deal with semicolons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .synthesisr.Rproj
 doc
 Meta
+.vscode

--- a/R/clean_functions.R
+++ b/R/clean_functions.R
@@ -14,6 +14,8 @@ clean_df <- function(data){
 clean_authors <- function(x){
   if(any(grepl("\\sand\\s|\\sAND\\s|\\s&\\s", x))){
     x <- gsub("\\sAND\\s|\\s&\\s", " and ", x)
+  }else if(grepl(";", x)){
+    x <- gsub(";(?=\\s[[:alpha:]]{2,})", " and ", x, perl = TRUE)
   }else{
     x <- gsub(",(?=\\s[[:alpha:]]{2,})", " and ", x, perl = TRUE)
   }


### PR DESCRIPTION
Adds some regex to clean_authors() within clean_functions.R to handle
cases in which authors are listed as lastname, firstname and seperated
by semicolons.

fixes #17 